### PR TITLE
adds "webapp" as dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -6,6 +6,7 @@ Package.describe({
 
 Package.on_use(function (api) {
   api.versionsFrom("METEOR@0.9.0");
+  api.use('webapp', 'server');
   api.add_files("basic-auth.js", 'server');
   api.export(['HttpBasicAuth'], 'server');
 });


### PR DESCRIPTION
It is needed to register the dependency in order to use `WebAppInternals`, otherwise you get `ReferenceError: WebAppInternals is not defined` at `HttpBasicAuth.protect (packages/jabbslad_basic-auth/packages/jabbslad_basic-auth.js:18:1).`
